### PR TITLE
Add function caching

### DIFF
--- a/kli.hpp
+++ b/kli.hpp
@@ -417,4 +417,8 @@ namespace kli {
 	}
 }
 
+#ifdef KLI_DISABLE_CACHE
+#define KLI_FN(name) ((decltype(&##name))(::kli::find_kernel_export<KLI_HASH_STR(#name)>()))
+#else
 #define KLI_FN(name) ((decltype(&##name))(::kli::find_kernel_export_cached<KLI_HASH_STR(#name)>()))
+#endif

--- a/kli.hpp
+++ b/kli.hpp
@@ -417,4 +417,4 @@ namespace kli {
 	}
 }
 
-#define KLI_FN(name) ((decltype(&##name))(::kli::find_kernel_export_cached(KLI_HASH_STR(#name))))
+#define KLI_FN(name) ((decltype(&##name))(::kli::find_kernel_export_cached<KLI_HASH_STR(#name)>()))

--- a/kli.hpp
+++ b/kli.hpp
@@ -374,7 +374,8 @@ namespace kli {
 		}
 	}
 
-	KLI_FORCEINLINE uintptr_t find_kernel_export(uint64_t export_hash)
+	template <uint64_t ExportHash>
+	KLI_FORCEINLINE uintptr_t find_kernel_export()
 	{
 		if (!cache::kernel_base)
 			cache::kernel_base = detail::find_kernel_base();
@@ -397,13 +398,23 @@ namespace kli {
 			// address_of_functions is indexed through an ordinal
 			// address_of_name_ordinals gets the ordinal through our own index - i.
 			//
-			if (export_entry_hash == export_hash)
+			if (export_entry_hash == ExportHash)
 				return cache::kernel_base + address_of_functions[address_of_name_ordinals[i]];
 		}
 
 		__debugbreak();
 		return { };
 	}
+
+	template <uint64_t ExportHash>
+	KLI_FORCEINLINE uintptr_t find_kernel_export_cached()
+	{
+		static uintptr_t address = 0;
+		if (!address)
+			address = find_kernel_export<ExportHash>();
+
+		return address;
+	}
 }
 
-#define KLI_FN(name) ((decltype(&##name))(::kli::find_kernel_export(KLI_HASH_STR(#name))))
+#define KLI_FN(name) ((decltype(&##name))(::kli::find_kernel_export_cached(KLI_HASH_STR(#name))))


### PR DESCRIPTION
Small but necessary change - function pointers are now cached so each KLI_FN invocation no longer looks through every ntoskrnl.exe export.